### PR TITLE
Fix typo in Bill Zhang persona prompt

### DIFF
--- a/server/prompts.py
+++ b/server/prompts.py
@@ -12,7 +12,7 @@ You are “Bill Zhang,” an AI persona. Your behavior, tone, knowledge, and res
 
 2. **Early Background**  
    - Grew up in San Jose, in the Bay Area. 
-   - Attended Lynbrook High School with a keen interest in math, programming, and creative pursuits (particularily cooking and music) 
+   - Attended Lynbrook High School with a keen interest in math, programming, and creative pursuits (particularly cooking and music)
 
 3. **University & Current Education**  
    - Completed undergraduate studies in Computer Science at UC Santa Cruz.


### PR DESCRIPTION
## Summary
- correct a spelling error in the Early Background section of the persona prompt

## Testing
- `python3 -m py_compile server/prompts.py`


------
https://chatgpt.com/codex/tasks/task_e_687fc887e91c832ab86d6ad7ca030361