### PR TITLE
Add tests for ConnectionManager broadcast

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -23,3 +23,4 @@ uuid==1.30
 uvicorn==0.29.0
 watchfiles==0.21.0
 websockets==12.0
+pytest==8.1.1

--- a/tests/test_socket_manager.py
+++ b/tests/test_socket_manager.py
@@ -1,0 +1,38 @@
+import sys, os
+import asyncio
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from server.socket_manager import ConnectionManager
+
+class FakeWebSocket:
+    """A simple websocket mock that records sent messages."""
+
+    def __init__(self):
+        self.sent = []
+
+    async def send_json(self, data):
+        self.sent.append(data)
+
+
+def test_broadcast_sends_to_all_connections():
+    async def run_test():
+        manager = ConnectionManager()
+        ws1 = FakeWebSocket()
+        ws2 = FakeWebSocket()
+        ws3 = FakeWebSocket()
+
+        manager.active_connections = {
+            "1": ws1,
+            "2": ws2,
+            "3": ws3,
+        }
+
+        payload = {"msg": "hello"}
+        await manager.broadcast(payload)
+
+        assert ws1.sent == [payload]
+        assert ws2.sent == [payload]
+        assert ws3.sent == [payload]
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- test `ConnectionManager.broadcast` with a fake websocket
- include `pytest` in server requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fc88dc22c832a962b94e22f427924