### PR TITLE
feat: show pointer on start voice button

### DIFF
--- a/client/src/components/app-sidebar.tsx
+++ b/client/src/components/app-sidebar.tsx
@@ -193,7 +193,7 @@ const VoiceChatSidebarComponent = ({
         {!isCalling ? (
           <Button
             onClick={toggleCall}
-            className="w-full bg-primary hover:bg-primary/90 text-primary-foreground py-6 rounded-xl transition-all duration-300 hover:shadow-glow"
+            className="w-full bg-primary hover:bg-primary/90 text-primary-foreground py-6 rounded-xl transition-all duration-300 hover:shadow-glow cursor-pointer"
           >
             <Mic className="mr-2 h-5 w-5" /> Start Voice Interaction
           </Button>


### PR DESCRIPTION
## Summary
- show pointer cursor when hovering over start voice interaction button

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba9d488010832a941a0970c4c635cc